### PR TITLE
chore: Add Trivy filesystem scan

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -30,15 +30,15 @@ jobs:
           exit-code: 0
           ignore-unfixed: false
 
-      # - name: Check for critical and high vulnerabilities
-      #   uses: aquasecurity/trivy-action@77137e9dc3ab1b329b7c8a38c2eb7475850a14e8
-      #   with:
-      #     scan-type: fs
-      #     scan-ref: .
-      #     format: table
-      #     severity: CRITICAL,HIGH
-      #     exit-code: 1
-      #     ignore-unfixed: false
+      - name: Check for critical and high vulnerabilities
+        uses: aquasecurity/trivy-action@77137e9dc3ab1b329b7c8a38c2eb7475850a14e8
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: 1
+          ignore-unfixed: false
 
       - name: Upload SARIF to Security tab
         if: always()


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions workflow to perform file system vulnerability scans using Trivy and surface results in the Security tab

CI:
- Introduce a security-scan workflow triggered on main branch events and manual dispatch
- Run Trivy FS scans with SARIF output and enforce failure on critical/high vulnerabilities
- Upload Trivy SARIF report to GitHub Security tab under a dedicated category