### PR TITLE
Update channel to 1.86.0 in `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Downstream, there were image build failures, e.g. see 
* [RHOAIENG-56584](https://redhat.atlassian.net/browse/RHOAIENG-56584)
* [RHOAIENG-58186](https://redhat.atlassian.net/browse/RHOAIENG-58186)

These build issues were resolved by bumping Rust to 1.86, so it would be good to reflect this upstream too

## Summary by Sourcery

Build:
- Bump the Rust toolchain channel from 1.84.0 to 1.86.0 in rust-toolchain.toml to align builds with the newer compiler version.