### PR TITLE
Censor debug logs, remove hard-coded DEBUG logs, set host to 127.0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -893,8 +902,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -905,8 +923,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -1366,10 +1390,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ serde_yml = "0.0.12"
 tokio = { version = "1.41.1", features = ["full", "macros", "rt-multi-thread"] }
 tower-http = { version = "0.6.2", features = ["trace"] }
 tracing = "0.1.41"
-tracing-subscriber = "0.3.19"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 native-tls = "0.2.12"
 openssl = "0.10.73"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,12 +52,17 @@ pub struct RouteConfig {
     pub fallback_message: Option<String>,
 }
 
-
 pub fn read_config(path: &str) -> GatewayConfig {
-    let result = fs::read_to_string(path).expect(&format!("could not read file: {}", path));
+    let result =
+        fs::read_to_string(path).unwrap_or_else(|_| panic!("could not read file: {}", path));
 
-    let mut cfg: GatewayConfig = serde_yml::from_str(&result).expect("failed to read in yaml config");
-    cfg.detectors = cfg.detectors.into_iter().map(|d| d.with_server_default()).collect();
+    let mut cfg: GatewayConfig =
+        serde_yml::from_str(&result).expect("failed to read in yaml config");
+    cfg.detectors = cfg
+        .detectors
+        .into_iter()
+        .map(|d| d.with_server_default())
+        .collect();
     cfg
 }
 
@@ -84,7 +89,11 @@ pub fn validate_registered_detectors(gateway_cfg: &GatewayConfig) {
         let mut seen_output = HashSet::new();
 
         for detector_name in &route.detectors {
-            if let Some(detector_cfg) = gateway_cfg.detectors.iter().find(|d| &d.name == detector_name) {
+            if let Some(detector_cfg) = gateway_cfg
+                .detectors
+                .iter()
+                .find(|d| &d.name == detector_name)
+            {
                 if detector_cfg.input {
                     let server = detector_cfg.server.as_ref().unwrap();
                     if !seen_input.insert(server) {
@@ -145,20 +154,21 @@ mod tests {
                 host: "localhost".to_string(),
                 port: Some(1234),
             },
-            detectors: vec![DetectorConfig {
-                name: "regex-1".to_string(),
-                server: Some("server-a".to_string()),
-                input: true,
-                output: false,
-                detector_params: None,
-            }, DetectorConfig {
-                name: "regex-2".to_string(),
-                server: Some("server-a".to_string()),
-                input: true,
-                output: false,
-                detector_params: None,
-            },
-
+            detectors: vec![
+                DetectorConfig {
+                    name: "regex-1".to_string(),
+                    server: Some("server-a".to_string()),
+                    input: true,
+                    output: false,
+                    detector_params: None,
+                },
+                DetectorConfig {
+                    name: "regex-2".to_string(),
+                    server: Some("server-a".to_string()),
+                    input: true,
+                    output: false,
+                    detector_params: None,
+                },
             ],
             routes: vec![RouteConfig {
                 name: "route1".to_string(),
@@ -178,20 +188,21 @@ mod tests {
                 host: "localhost".to_string(),
                 port: Some(1234),
             },
-            detectors: vec![DetectorConfig {
-                name: "regex-1".to_string(),
-                server: Some("server-a".to_string()),
-                input: false,
-                output: true,
-                detector_params: None,
-            }, DetectorConfig {
-                name: "regex-2".to_string(),
-                server: Some("server-a".to_string()),
-                input: false,
-                output: true,
-                detector_params: None,
-            },
-
+            detectors: vec![
+                DetectorConfig {
+                    name: "regex-1".to_string(),
+                    server: Some("server-a".to_string()),
+                    input: false,
+                    output: true,
+                    detector_params: None,
+                },
+                DetectorConfig {
+                    name: "regex-2".to_string(),
+                    server: Some("server-a".to_string()),
+                    input: false,
+                    output: true,
+                    detector_params: None,
+                },
             ],
             routes: vec![RouteConfig {
                 name: "route1".to_string(),
@@ -210,20 +221,21 @@ mod tests {
                 host: "localhost".to_string(),
                 port: Some(1234),
             },
-            detectors: vec![DetectorConfig {
-                name: "regex-1".to_string(),
-                server: Some("server-a".to_string()),
-                input: true,
-                output: false,
-                detector_params: None,
-            }, DetectorConfig {
-                name: "regex-2".to_string(),
-                server: Some("server-a".to_string()),
-                input: false,
-                output: true,
-                detector_params: None,
-            },
-
+            detectors: vec![
+                DetectorConfig {
+                    name: "regex-1".to_string(),
+                    server: Some("server-a".to_string()),
+                    input: true,
+                    output: false,
+                    detector_params: None,
+                },
+                DetectorConfig {
+                    name: "regex-2".to_string(),
+                    server: Some("server-a".to_string()),
+                    input: false,
+                    output: true,
+                    detector_params: None,
+                },
             ],
             routes: vec![RouteConfig {
                 name: "route1".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::{
 };
 use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
+use tracing_subscriber::EnvFilter;
 use anyhow::Context;
 
 mod api;
@@ -57,18 +58,19 @@ fn get_orchestrator_detectors(
 
 #[tokio::main]
 async fn main() {
-    let config_path = env::var("GATEWAY_CONFIG").unwrap_or("config/config.yaml".to_string());
-    tracing::debug!("Using config path: {}", config_path);
-    let gateway_config = config::read_config(&config_path);
-    tracing::debug!("Loaded gateway config: {:?}", gateway_config);
-    validate_registered_detectors(&gateway_config);
-    tracing::debug!("Validated registered detectors");
-
     tracing_subscriber::fmt()
-        .with_max_level(tracing::Level::DEBUG)
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .with_target(false)
         .compact()
         .init();
+
+    let config_path = env::var("GATEWAY_CONFIG").unwrap_or("config/config.yaml".to_string());
+    tracing::debug!("Using config path: {}", config_path);
+    let gateway_config = config::read_config(&config_path);
+    validate_registered_detectors(&gateway_config);
 
     let (client, scheme) =
         build_orchestrator_client(&gateway_config.orchestrator.host)
@@ -122,7 +124,7 @@ async fn main() {
         }
     }
 
-    let host = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    let host = env::var("HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
     tracing::debug!("Using host: {}", host);
 
     let ip: IpAddr = host.parse().expect("Failed to parse host IP address");
@@ -160,8 +162,6 @@ async fn handle_chat_completions(
     orchestrator_client: Arc<reqwest::Client>,
     scheme: String,
 ) -> Result<Response, (StatusCode, String)> {
-    tracing::debug!("handle_chat_completions called with payload: {:?}", payload);
-
     // Check if streaming is requested
     let is_streaming = payload
         .as_object()
@@ -207,11 +207,8 @@ async fn handle_non_streaming_generation(
     orchestrator_client: Arc<reqwest::Client>,
     scheme: String,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    tracing::debug!("handle_non_streaming_generation called with payload: {:?}", payload);
-
     let orchestrator_detectors =
         get_orchestrator_detectors(detectors.clone(), gateway_config.detectors.clone());
-    tracing::debug!("Orchestrator detectors: {:?}", orchestrator_detectors);
 
     let mut payload = payload.as_object_mut();
 
@@ -234,8 +231,6 @@ async fn handle_non_streaming_generation(
         "detectors".to_string(),
         serde_json::to_value(&orchestrator_detectors).unwrap(),
     );
-    tracing::debug!("Payload after inserting detectors: {:?}", payload);
-
     let response_result =
         orchestrator_post_request(payload, &headers, &url, &orchestrator_client).await;
 
@@ -244,7 +239,7 @@ async fn handle_non_streaming_generation(
             let detection =
                 check_payload_detections(&orchestrator_response.detections, route_fallback_message);
             if let Some(message) = detection {
-                tracing::debug!("Fallback message triggered: {:?}", message);
+                tracing::debug!("Fallback message triggered");
                 orchestrator_response.choices = vec![message];
             }
             Ok(Json(json!(orchestrator_response)).into_response())
@@ -265,11 +260,8 @@ async fn handle_streaming_generation(
     orchestrator_client: Arc<reqwest::Client>,
     scheme: String,
 ) -> Result<impl IntoResponse, (StatusCode, String)> {
-    tracing::debug!("handle_streaming_generation called with payload: {:?}", payload);
-
     let orchestrator_detectors =
         get_orchestrator_detectors(detectors.clone(), gateway_config.detectors.clone());
-    tracing::debug!("Orchestrator detectors: {:?}", orchestrator_detectors);
 
     let mut payload = payload.as_object_mut();
 
@@ -292,8 +284,6 @@ async fn handle_streaming_generation(
         "detectors".to_string(),
         serde_json::to_value(&orchestrator_detectors).unwrap(),
     );
-    tracing::debug!("Payload after inserting detectors: {:?}", payload);
-
     let response_result =
         orchestrator_streaming_request(payload, &headers, &url, &orchestrator_client).await;
 
@@ -411,23 +401,13 @@ async fn orchestrator_post_request(
     url: &str,
     client: &reqwest::Client,
 ) -> Result<OrchestratorResponse, anyhow::Error> {
-    tracing::debug!(
-        "Sending POST request to {} with payload: {:?}",
-        url,
-        payload
-    );
+    tracing::debug!("Sending POST request to {}", url);
 
     let mut req = client.post(url).json(&payload);
 
-    // Forward authorization headers
     for (name, value) in headers.iter() {
-        // filter out headers t
-        tracing::debug!("Header {}: {:?}", name, value);
         let name_str = name.as_str().to_ascii_lowercase();
-        if name_str == "authorization" {
-            req = req.header(name, value);
-        }
-        if name_str.starts_with("x-forwarded") {
+        if name_str == "authorization" || name_str.starts_with("x-forwarded") {
             req = req.header(name, value);
         }
     }
@@ -458,20 +438,17 @@ async fn orchestrator_post_request(
         tracing::error!("Failed to read response body: {:?}", e);
         String::new()
     });
-    tracing::debug!("Received response status: {}, body: {}", status, text);
+    tracing::debug!("Received response status: {}", status);
 
     if !status.is_success() {
-        // Return the error with the status code and response body
-        tracing::error!("Orchestrator returned error status {}: {}", status, text);
+        tracing::error!("Orchestrator returned error status {}", status);
         return Err(anyhow::anyhow!(
-            "Orchestrator returned error status {}: {}",
+            "Orchestrator returned error status {}",
             status,
-            text
         ));
     }
 
     let json: serde_json::Value = serde_json::from_str(&text)?;
-    tracing::debug!("Parsed JSON response: {:?}", json);
     Ok(serde_json::from_value(json).expect("unexpected json response from request"))
 }
 
@@ -481,22 +458,13 @@ async fn orchestrator_streaming_request(
     url: &str,
     client: &reqwest::Client,
 ) -> Result<impl futures::Stream<Item = Result<String, anyhow::Error>>, anyhow::Error> {
-    tracing::debug!(
-        "Sending streaming POST request to {} with payload: {:?}",
-        url,
-        payload
-    );
+    tracing::debug!("Sending streaming POST request to {}", url);
 
     let mut req = client.post(url).json(&payload);
 
-    // Forward authorization headers
     for (name, value) in headers.iter() {
-        tracing::debug!("Header {}: {:?}", name, value);
         let name_str = name.as_str().to_ascii_lowercase();
-        if name_str == "authorization" {
-            req = req.header(name, value);
-        }
-        if name_str.starts_with("x-forwarded") {
+        if name_str == "authorization" || name_str.starts_with("x-forwarded") {
             req = req.header(name, value);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
+use anyhow::Context;
 use axum::http::HeaderMap;
+use axum::response::sse::{Event, KeepAlive};
 use axum::{
     http::StatusCode,
-    response::{IntoResponse, Sse, Response},
+    response::{IntoResponse, Response, Sse},
     routing::post,
-    Json, Router
+    Json, Router,
 };
-use axum::response::sse::{Event, KeepAlive};
 use config::{validate_registered_detectors, DetectorConfig, GatewayConfig};
 use futures::StreamExt;
 use serde_json::json;
@@ -20,14 +21,13 @@ use std::{
 use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
-use anyhow::Context;
 
 mod api;
 mod config;
 
 use api::{
     Detections, GenerationChoice, GenerationMessage, OrchestratorDetector, OrchestratorResponse,
-    StreamingResponse, StreamingDelta,
+    StreamingDelta, StreamingResponse,
 };
 
 fn get_orchestrator_detectors(
@@ -40,7 +40,10 @@ fn get_orchestrator_detectors(
     for detector in detector_config {
         if detectors.contains(&detector.name) && detector.detector_params.is_some() {
             let detector_params = detector.detector_params.unwrap();
-            let key = detector.server.clone().unwrap_or_else(|| detector.name.clone());
+            let key = detector
+                .server
+                .clone()
+                .unwrap_or_else(|| detector.name.clone());
             if detector.input {
                 input_detectors.insert(key.clone(), detector_params.clone());
             }
@@ -60,8 +63,7 @@ fn get_orchestrator_detectors(
 async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("info")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
         .with_target(false)
         .compact()
@@ -72,9 +74,8 @@ async fn main() {
     let gateway_config = config::read_config(&config_path);
     validate_registered_detectors(&gateway_config);
 
-    let (client, scheme) =
-        build_orchestrator_client(&gateway_config.orchestrator.host)
-            .expect("Failed to build HTTP(s) client for communicating with orchestrator");
+    let (client, scheme) = build_orchestrator_client(&gateway_config.orchestrator.host)
+        .expect("Failed to build HTTP(s) client for communicating with orchestrator");
     let orchestrator_client = Arc::new(client);
 
     let mut app = Router::new().layer(
@@ -94,17 +95,20 @@ async fn main() {
         // Single endpoint that handles both streaming and non-streaming based on payload
         app = app.route(
             &path,
-            post(move |headers: HeaderMap, Json(payload): Json<serde_json::Value>| async move {
-                handle_chat_completions(
-                    headers,
-                    Json(payload),
-                    detectors,
-                    gateway_config,
-                    fallback_message,
-                    orchestrator_client,
-                    scheme,
-                ).await
-            }),
+            post(
+                move |headers: HeaderMap, Json(payload): Json<serde_json::Value>| async move {
+                    handle_chat_completions(
+                        headers,
+                        Json(payload),
+                        detectors,
+                        gateway_config,
+                        fallback_message,
+                        orchestrator_client,
+                        scheme,
+                    )
+                    .await
+                },
+            ),
         );
 
         tracing::info!("exposed endpoint: {}", path);
@@ -169,7 +173,7 @@ async fn handle_chat_completions(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let result = if is_streaming {
+    if is_streaming {
         handle_streaming_generation(
             headers,
             Json(payload),
@@ -193,9 +197,7 @@ async fn handle_chat_completions(
         )
         .await
         .map(|response| response.into_response())
-    };
-
-    result
+    }
 }
 
 async fn handle_non_streaming_generation(
@@ -215,14 +217,11 @@ async fn handle_non_streaming_generation(
     let url: String = match gateway_config.orchestrator.port {
         Some(port) => format!(
             "{}://{}:{}/api/v2/chat/completions-detection",
-            scheme,
-            gateway_config.orchestrator.host,
-            port
+            scheme, gateway_config.orchestrator.host, port
         ),
         None => format!(
             "{}://{}/api/v2/chat/completions-detection",
-            scheme,
-            gateway_config.orchestrator.host
+            scheme, gateway_config.orchestrator.host
         ),
     };
     tracing::debug!("Orchestrator URL: {}", url);
@@ -268,14 +267,11 @@ async fn handle_streaming_generation(
     let url: String = match gateway_config.orchestrator.port {
         Some(port) => format!(
             "{}://{}:{}/api/v2/chat/completions-detection",
-            scheme,
-            gateway_config.orchestrator.host,
-            port
+            scheme, gateway_config.orchestrator.host, port
         ),
         None => format!(
             "{}://{}/api/v2/chat/completions-detection",
-            scheme,
-            gateway_config.orchestrator.host
+            scheme, gateway_config.orchestrator.host
         ),
     };
     tracing::debug!("Orchestrator URL: {}", url);
@@ -293,17 +289,20 @@ async fn handle_streaming_generation(
                 match chunk_result {
                     Ok(chunk) => {
                         // Check if we need to apply fallback message
-                        if let Ok(mut streaming_response) = serde_json::from_str::<StreamingResponse>(&chunk) {
+                        if let Ok(mut streaming_response) =
+                            serde_json::from_str::<StreamingResponse>(&chunk)
+                        {
                             if let Some(fallback_message) = &route_fallback_message {
                                 if streaming_response.detections.is_some() {
                                     // Apply fallback message to the first chunk
-                                    if streaming_response.choices.len() > 0 {
+                                    if !streaming_response.choices.is_empty() {
                                         streaming_response.choices[0].delta = StreamingDelta {
                                             content: Some(fallback_message.clone()),
                                             role: Some("assistant".to_string()),
                                             tool_calls: None,
                                         };
-                                        streaming_response.choices[0].finish_reason = Some("stop".to_string());
+                                        streaming_response.choices[0].finish_reason =
+                                            Some("stop".to_string());
                                     }
                                 }
                             }
@@ -311,8 +310,12 @@ async fn handle_streaming_generation(
                             match serde_json::to_string(&streaming_response) {
                                 Ok(json_str) => Ok(Event::default().data(json_str)),
                                 Err(e) => {
-                                    tracing::error!("Failed to serialize streaming response: {}", e);
-                                    Ok(Event::default().data("{\"error\": \"serialization failed\"}"))
+                                    tracing::error!(
+                                        "Failed to serialize streaming response: {}",
+                                        e
+                                    );
+                                    Ok(Event::default()
+                                        .data("{\"error\": \"serialization failed\"}"))
                                 }
                             }
                         } else {
@@ -476,8 +479,14 @@ async fn orchestrator_streaming_request(
 
     let status = response.status();
     if !status.is_success() {
-        let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
-        let err_msg = format!("Orchestrator returned error status {}: {}", status, error_text);
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        let err_msg = format!(
+            "Orchestrator returned error status {}: {}",
+            status, error_text
+        );
         tracing::error!("{}", err_msg);
         anyhow::bail!(err_msg);
     }
@@ -495,8 +504,7 @@ async fn orchestrator_streaming_request(
                 let mut data_lines = Vec::new();
 
                 for line in lines {
-                    if line.starts_with("data: ") {
-                        let data = &line[6..]; // Remove "data: " prefix
+                    if let Some(data) = line.strip_prefix("data: ") {
                         if data != "[DONE]" {
                             data_lines.push(data.to_string());
                         }


### PR DESCRIPTION
Remove payload information from debug logs, fix broken log levels, enforce binding to 127.0.0.1.

## Summary by Sourcery

Tighten logging and networking behavior by censoring sensitive data in debug logs, relying on environment-based log filtering, and binding the gateway to localhost by default.

New Features:
- Support configuring log levels via environment using tracing-subscriber EnvFilter.

Bug Fixes:
- Ensure authorization and x-forwarded headers are forwarded consistently in orchestrator requests.

Enhancements:
- Remove detailed payload and response body contents from debug logs to avoid leaking sensitive information.
- Simplify various debug messages to focus on high-level events rather than full data dumps.

Build:
- Enable the env-filter feature for tracing-subscriber in Cargo.toml.